### PR TITLE
Codex: Add cutoff pagination check

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,12 @@ dotnet run --project HubClient.Production/HubClient.Production.csproj -c Release
 
 # Only download profile data for a specific FID (977233)
 dotnet run --project HubClient.Production/HubClient.Production.csproj -c Release --profiles --mine
+
+# Only download messages from the last 30 days
+dotnet run --project HubClient.Production/HubClient.Production.csproj -c Release --days 30
 ```
+
+Pagination automatically stops when a page contains a message older than the cutoff time.
 
 This will start downloading all messages to:
 - Casts: `outputs/casts/cast_messages/`


### PR DESCRIPTION
## Context
Codex chat: https://chatgpt.com/s/cd_682d14160c9481919b4d5271bfd0abe6

## Summary
- check each page for messages older than the days cutoff
- stop pagination when the cutoff is reached
- document that pagination ends once an older page is encountered

## Testing
- `dotnet build HubClient/HubClient.Production/HubClient.Production.csproj -c Release` *(fails: Unable to load the service index for nuget.org)*